### PR TITLE
making the query function reusable

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-require('..').run()
+require('../src/index').run()
 .catch(require('@oclif/errors/handle'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,14 +217,6 @@
         "apollo-link": "^1.2.2"
       }
     },
-    "apollo-link-utilities": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/apollo-link-utilities/-/apollo-link-utilities-0.0.0.tgz",
-      "integrity": "sha512-WOHXxnE+cNd9vaOaP/YOA7xPs5R3hUEeXcDvyllTFeblYl/vxo2Jq/z9rcdat8mzQ6H4RMw/c4yG7VdnBxEOpg==",
-      "requires": {
-        "apollo-link": "^1.0.7"
-      }
-    },
     "apollo-link-ws": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/apollo-link-ws/-/apollo-link-ws-1.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "oclif"
   ],
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "src/query.js",
   "oclif": {
     "bin": "gq"
   },

--- a/src/callbacks.js
+++ b/src/callbacks.js
@@ -14,6 +14,7 @@ const querySuccessCb = (ctx, response, queryType, parsedQuery, endpoint) => {
 };
 
 const queryErrorCb = (ctx, queryError, queryType, parsedQuery, endpoint) => {
+  cli.action.stop('error');
   if (!queryType) {
     handleGraphQLError(queryError);
   } else if (queryType == 'subscription') {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const Query = require('./query');
+const query = require('./query');
 const {Command, flags} = require('@oclif/command');
 const {cli} = require('cli-ux');
 const fs = require('fs');
@@ -36,7 +36,8 @@ class GraphqurlCommand extends Command {
     const errorCallback = (error, queryType, parsedQuery) => {
       queryErrorCb(this, error, queryType, parsedQuery);
     };
-    await Query(queryOptions, successCallback, errorCallback);
+    cli.action.start(`Executing at ${flags.endpoint}`);
+    await query(queryOptions, successCallback, errorCallback);
   }
 
   parseHeaders(headersArray) {
@@ -145,3 +146,4 @@ GraphqurlCommand.args = [
 ];
 
 module.exports = GraphqurlCommand;
+module.exports.query = query;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,46 @@
+const { SubscriptionClient } = require('subscriptions-transport-ws');
+const { WebSocketLink } = require('apollo-link-ws');
+const ws = require('ws');
+const { execute } = require('apollo-link');
+
+const makeObservable = (query, variables, endpoint, headers, errorCb) => {
+  return execute(
+    makeWsLink(endpoint, headers, query, errorCb),
+    {
+      query,
+      variables
+    }
+  );
+};
+
+
+const makeWsLink = function(uri, headers, query, errorCb) {
+  return new WebSocketLink(new SubscriptionClient(
+    uri,
+    {
+      reconnect: true,
+      connectionParams: {
+        headers
+      },
+      connectionCallback: (error) => {
+        if (error) {
+          if (!errorCb) {
+            console.error(error);
+            return;
+          }
+          errorCb(
+            error,
+            'subscription',
+            query
+          );
+        }
+      }
+    },
+    ws
+  ));
+};
+
+module.exports = {
+  makeWsLink,
+  makeObservable
+};


### PR DESCRIPTION
the `query` function can be imported as

```
const query = require('graphqurl');
```