### PR TITLE
add proxy to avoid cors issues when using graphiql

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "apollo-link-ws": "^1.0.8",
     "cli-ux": "^4.7.3",
     "express": "^4.16.3",
+    "express-http-proxy": "^1.2.0",
     "graphql": "0.9.1",
     "graphql-language-service-interface": "^1.2.2",
     "graphql-language-service-utils": "^1.2.2",


### PR DESCRIPTION
this is a pretty simple implementation and dosn't allow to disable the proxy
the host splitting is also somewhat sketchy
and the host is not shown on the page (only the path) since displayed and used host are the same
but it works and allows using graphqurl on sites without cors headers