### PR TITLE
Rethrow human-readable error on schema introspection

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -67,7 +67,7 @@ class GraphqurlCommand extends Command {
       name: flags.name,
     };
 
-    cli.action.start("Executing query");
+    cli.action.start('Executing query');
     await query(queryOptions, successCallback, errorCallback);
   }
 

--- a/src/command.js
+++ b/src/command.js
@@ -49,26 +49,27 @@ class GraphqurlCommand extends Command {
       queryErrorCb(this, error, queryType, parsedQuery);
     };
 
-    if (queryString === null) {
-      queryString = await executeQueryFromTerminalUI({
-        endpoint: endpoint,
-        headers,
-        variables,
-        name: flags.name,
-      }, successCallback, errorCallback);
-      return;
-    }
-
     const queryOptions = {
-      query: queryString,
-      endpoint: endpoint,
+      endpoint,
       headers,
       variables,
       name: flags.name,
     };
 
+    if (queryString === null) {
+      queryString = await executeQueryFromTerminalUI(queryOptions, successCallback, errorCallback);
+      return;
+    }
+
     cli.action.start('Executing query');
-    await query(queryOptions, successCallback, errorCallback);
+    await query(
+      {
+        query: queryString,
+        ...queryOptions,
+      },
+      successCallback,
+      errorCallback
+    );
   }
 
   parseHeaders(headersArray) {

--- a/src/command.js
+++ b/src/command.js
@@ -49,27 +49,26 @@ class GraphqurlCommand extends Command {
       queryErrorCb(this, error, queryType, parsedQuery);
     };
 
+    if (queryString === null) {
+      queryString = await executeQueryFromTerminalUI({
+        endpoint,
+        headers,
+        variables,
+        name: flags.name,
+      }, successCallback, errorCallback);
+      return;
+    }
+
     const queryOptions = {
+      query: queryString,
       endpoint,
       headers,
       variables,
       name: flags.name,
     };
 
-    if (queryString === null) {
-      queryString = await executeQueryFromTerminalUI(queryOptions, successCallback, errorCallback);
-      return;
-    }
-
-    cli.action.start('Executing query');
-    await query(
-      {
-        query: queryString,
-        ...queryOptions,
-      },
-      successCallback,
-      errorCallback
-    );
+    cli.action.start("Executing query");
+    await query(queryOptions, successCallback, errorCallback);
   }
 
   parseHeaders(headersArray) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -154,8 +154,10 @@ const executeQueryFromTerminalUI = async (queryOptions, successCb, errorCb)  => 
   } = queryOptions;
   cli.action.start('Introspecting schema');
 
-  const schemaResponse = await query({endpoint: endpoint, query: introspectionQuery, headers: headers})
-  .catch(err => {
+  let schemaResponse;
+  try {
+    schemaResponse = await query({endpoint: endpoint, query: introspectionQuery, headers: headers})
+  } catch(err) {
     if (err.message && err.message.startsWith('Network error: Unexpected token')) {
       const {networkError} = err;
 
@@ -168,7 +170,7 @@ const executeQueryFromTerminalUI = async (queryOptions, successCb, errorCb)  => 
     }
 
     throw err;
-  });
+  };
 
   cli.action.stop('done');
   const r = schemaResponse.data;

--- a/src/ui.js
+++ b/src/ui.js
@@ -156,8 +156,8 @@ const executeQueryFromTerminalUI = async (queryOptions, successCb, errorCb)  => 
 
   let schemaResponse;
   try {
-    schemaResponse = await query({endpoint: endpoint, query: introspectionQuery, headers: headers})
-  } catch(err) {
+    schemaResponse = await query({endpoint: endpoint, query: introspectionQuery, headers: headers});
+  } catch (err) {
     if (err.message && err.message.startsWith('Network error: Unexpected token')) {
       const {networkError} = err;
 
@@ -170,7 +170,7 @@ const executeQueryFromTerminalUI = async (queryOptions, successCb, errorCb)  => 
     }
 
     throw err;
-  };
+  }
 
   cli.action.stop('done');
   const r = schemaResponse.data;

--- a/src/ui.js
+++ b/src/ui.js
@@ -153,7 +153,23 @@ const executeQueryFromTerminalUI = async (queryOptions, successCb, errorCb)  => 
     headers,
   } = queryOptions;
   cli.action.start('Introspecting schema');
-  const schemaResponse = await query({endpoint: endpoint, query: introspectionQuery, headers: headers});
+
+  const schemaResponse = await query({endpoint: endpoint, query: introspectionQuery, headers: headers})
+  .catch(err => {
+    if (err.message && err.message.startsWith('Network error: Unexpected token')) {
+      const {networkError} = err;
+
+      throw new Error(
+        `Invalid GraphQL endpoint${
+          networkError ?
+            `: [${networkError.statusCode}] ${networkError.response.statusText}` :
+            ''
+        }`);
+    }
+
+    throw err;
+  });
+
   cli.action.stop('done');
   const r = schemaResponse.data;
   // term.fullscreen(true);


### PR DESCRIPTION
_Closes https://github.com/hasura/graphqurl/issues/18._

This PR shows a human-readable error when schema introspection fails on JSON parsing.

## Before

```
Introspecting schema... !
Error: Network error: Unexpected token < in JSON at position 0
    at new ApolloError (~/workspace/graphqurl/node_modules/apollo-client/bundle.umd.js:124:32)
    at ~/workspace/graphqurl/node_modules/apollo-client/bundle.umd.js:1248:45
    at ~/workspace/graphqurl/node_modules/apollo-client/bundle.umd.js:1680:21
    at Array.forEach (<anonymous>)
    at ~/workspace/graphqurl/node_modules/apollo-client/bundle.umd.js:1679:22
    at Map.forEach (<anonymous>)
    at QueryManager.broadcastQueries (~/workspace/graphqurl/node_modules/apollo-client/bundle.umd.js:1672:26)
    at ~/workspace/graphqurl/node_modules/apollo-client/bundle.umd.js:1175:35
```

## After

```
Introspecting schema... !
Error: Invalid GraphQL endpoint: [405] Method Not Allowed
    at query.catch.err (~/workspace/graphqurl/src/ui.js:162:13)
```

## Questions

I've rethrown the error in [ui.js](https://github.com/hasura/graphqurl/commit/bde06b3c01a52ee64eff6aa82a4e74358684c1af#diff-063f40abddd81fca68d3f38f2f3137e7R157-R170) but I'm not 100% sure if it's the proper place. \
My first attempt was to wrap [lines 59 to 72 of command.js](https://github.com/hasura/graphqurl/commit/af48a0f6c2dc6fd336a9c155d28999e633f2d4fa#diff-2ce4a9c4c2c2bf320df2efab7881c510R59-R72) in a try-catch and doing it there. (That's why I moved `queryOptions` assignment a little bit higher. I've decided to leave it to make the code a little bit more DRY.)


If there's anything that needs some more work just let me know :)