### PR TITLE
Pass headers to introspection query

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -158,7 +158,8 @@ const executeQueryFromTerminalUI = async (queryOptions, successCb, errorCb)  => 
     endpoint,
     headers,
   });
-  const schemaResponse = await client.query({query: getIntrospectionQuery()}, null, errorCb);
+  const introspectionOpts = {query: getIntrospectionQuery(), headers: headers};
+  const schemaResponse = await client.query(introspectionOpts, null, errorCb);
   cli.action.stop('done');
   const r = schemaResponse.data;
   // term.fullscreen(true);


### PR DESCRIPTION
This keeps introspection query in TUI in line with behaviour when
using the introspection flag. It is also essential for use with
APIs that require authorization to introspect the schema.