### PR TITLE
fix typo on variablesJSON shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ gq ENDPOINT [-q QUERY]
 | `--query`           | `-q`      | GraphQL query to execute                                                                              |
 | `--header`          | `-H`      | request header                                                                                        |
 | `--variable`        | `-v`      | Variables used in the query                                                                           |
-| `--variablesJSON`   | `-n`      | Variables used in the query as JSON                                                                   |
+| `--variablesJSON`   | `-j`      | Variables used in the query as JSON                                                                   |
 | `--graphiql`        | `-i`      | Open GraphiQL with the given endpoint, headers, query and variables                                   |
 | `--graphiqlAddress` | `-a`      | Address to use for GraphiQL. (Default: `localhost`)                                                   |
 | `--graphiqlPort`    | `-p`      | Port to use for GraphiQL                                                                              |


### PR DESCRIPTION
Current README.md has a typo on `--variablesJSON` shorthand as `-n`.

It should be `-j`. This PR fixed the typo.