### PR TITLE
Update header parsing to allow double-escaped ":"

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -69,7 +69,7 @@ class GraphqurlCommand extends Command {
     let headerObject = {};
     if (headersArray) {
       for (let h of headersArray) {
-        const parts = h.split(':');
+        const parts = h.split(/[^\\]:/);
         if (parts.length !== 2) {
           this.error(`cannot parse header '${h}' (multiple ':')`);
         }


### PR DESCRIPTION
# What Does This PR Do?
- Modifies header parsing logic to leverage regex instead of basic split

# Why?
Currently, any header value that contains literal colon characters is blanket rejected by these lines of code. My first impulse as a user was to try escaping those characters. However, I quickly realized that the logic didn't support escaping chars either. This regex split should only select colon characters not preceded by a double escape. Double escape must be used instead of single escape, since JS' strings will infer a regular escape as a standard escape char for the string system and store it without those escape chars.

# Questions to Think About :thinking: 
Negative lookbehind support (which this regex uses) isn't great across older JS versions - I believe ES2018 was when support was added. If compatibility is an issue let me know, and I can probably put together an alternative approach that still allows escaping these chars.