### PR TITLE
Add default Content-Type header

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -36,15 +36,22 @@ const makeClient = options => {
       variables,
       headers: headerOverrides,
     } = queryOptions;
+
+    const headers = {
+      ...clientContext.headers,
+      ...(headerOverrides || {}),
+    };
+    const isExistContentTypeKey = Object.keys(headers).some(key => /content-type/gi.test(key));
+    if (!isExistContentTypeKey) {
+      headers['Content-Type'] = 'application/json';
+    }
+
     try {
       const response = await fetch(
         clientContext.endpoint,
         {
           method: 'POST',
-          headers: {
-            ...clientContext.headers,
-            ...(headerOverrides || {}),
-          },
+          headers,
           body: JSON.stringify({query, variables: (variables || {})}),
         },
       );


### PR DESCRIPTION
Related issue: #97 
resolve #97 

- Add  `Content-Type: application/json` to default header if does not receive content-type header from CLI.
  - Just before send to request to GraphQL server with the merged headers object, I use regex to check the key in the headers object case-insensitively.
  - If exist content-type in headers object nothing happens but does not exist content-type, add `Content-Type: application/json` to headers object.