### PR TITLE
Don't modify header value when parsing corresponding CLI argument

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -80,10 +80,11 @@ class GraphqurlCommand extends Command {
     if (headersArray) {
       for (let h of headersArray) {
         const parts = h.split(':');
-        if (parts.length !== 2) {
-          this.error(`cannot parse header '${h}' (multiple ':')`);
+        if (parts.length < 2) {
+          this.error(`cannot parse header '${h}' (no ':')`);
         }
-        headerObject[parts[0].trim()] = parts[1].trim();
+        const headerName = parts.splice(0, 1)[0].trim();
+        headerObject[headerName] = parts.join(':').trimLeft();
       }
     }
     return headerObject;


### PR DESCRIPTION
This an alternative to #82 and solves the same problem: gq cuts provided header value after colon but it shouldn't do that. This PR reconstructs header value from parts obtained after parsing cli argument and extracting header name thus making in possible to pass intended header value to query function.