### PR TITLE
`gq -v key=val` accept '=' in the val (fix #134)

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -149,10 +149,10 @@ class GraphqurlCommand extends Command {
     if (flags.variable) {
       for (let v of flags.variable) {
         const parts = v.split('=');
-        if (parts.length !== 2) {
-          this.error(`cannot parse variable '${v} (multiple '=')`);
+        var val = parts.slice(1).join('=').trim();
+        if (val.length === 0) {
+          this.error(`cannot parse variable '${v} (no '=' found)`);
         }
-        var val = parts[1].trim();
         try {
           val = JSON.parse(val);
         } catch (err) {


### PR DESCRIPTION
This PR is to allow the `val` parameter of the `gq -v key=val` command to include `=`. 

The most common use case I have in mind is to pass a Base64 encoded value to the "val" of the "v" option.

